### PR TITLE
Add rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 .envrc
 pgdata/
+
+data/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This documentation will guide you through:
 ## Prerequisites
 
 - **API Access**:
-  At the moment, the access is free of charge. You only need to query the API endpoints at the addresses below:
+  At the moment, the access is free of charge, but rate limited for Gnosis Mainnet. You only need to query the API endpoints at the addresses below:
   - **Chiado**: `https://shutter-api.chiado.staging.shutter.network/api/[ADD_ENDPOINT]`
   - **Mainnet**: `https://shutter-api.shutter.network/api/[ADD_ENDPOINT]`
 
@@ -59,6 +59,29 @@ This documentation will guide you through:
 - **Address of the API**:
   - **Chiado Address**: `0xb9C303443c9af84777e60D5C987AbF0c43844918`
   - **Gnosis Address**: `0x228DefCF37Da29475F0EE2B9E4dfAeDc3b0746bc`
+
+### Rate limits / Authorization
+
+For unauthorized access, the API on Gnosis Mainnet is rate limited with these limits per endpoint and remote ip:
+
+  - `/register_identity` 5 requests per 24 hours
+  - `/get_data_for_encryption` 10 requests per 24 hours
+  - `/get_decryption_key` 20 requests per 24 hours
+  - `/decrypt_commitment` 10 requests per 24 hours
+
+We recommend using Chiado for development, because there are no rate limits in place.
+
+If you need higher limits, contact [loring@brainbot.com](mailto:loring@brainbot.com) to request an API key.
+
+Authorized requests have these limits:
+
+  - `/register_identity` 500 requests per 24 hours
+  - `/get_data_for_encryption` 1000 requests per 24 hours
+  - `/get_decryption_key` 2000 requests per 24 hours
+  - `/decrypt_commitment` 1000 requests per 24 hours
+
+Authorization is done by using an `Authorization: Bearer $API_KEY` header, when calling the API.
+
 ---
 
 ## Endpoints

--- a/apikeys/apikeys.py
+++ b/apikeys/apikeys.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+# ]
+# ///
+
+"""
+Utility for handling API keys with caddy. There are two functions:
+    - generating new keys and store them in the user database .csv (${KEYS_FILE})
+    - compiling a Caddyfile snippet for using those keys (${CADDY_SNIPPET})
+
+Without arguments it is started interactively and will ask for a reference for a new key.
+
+If used in a docker-compose setup, it can be run with the `--compile` flag, that will
+non-interactively compile the `Caddyfile` snippet to use.
+"""
+
+import os
+import sys
+import secrets
+from typing import Dict
+
+
+KEYS_FILE = os.environ.get("KEYS_FILE", "users.csv")
+CADDY_SNIPPET = os.environ.get("CADDY_SNIPPET", "apikeys")
+
+
+def generate_token() -> str:
+    return secrets.token_hex(32)
+
+
+def read_users() -> Dict[str, str]:
+    try:
+        with open(KEYS_FILE) as f:
+            users = {
+                name.strip(): key.strip()
+                for name, key in [l.split(",") for l in f.readlines()]
+            }
+        if "username" in users:
+            users.pop("username")
+        if any(len(key) < 32 for key in users.values()):
+            sys.exit(
+                f"Malformed keys: {list(filter(lambda _: len(_) < 32, users.values()))}"
+            )
+        return users
+    except FileNotFoundError:
+        return {}
+
+
+def dump_users(users: Dict[str, str]) -> None:
+    with open(KEYS_FILE, "wb") as f:
+        f.write(b"username,apikey\n")
+        f.writelines([f"{user},{key}\n".encode() for user, key in users.items()])
+    print(f"Wrote user database to '{KEYS_FILE}'")
+
+
+def compile(users: Dict[str, str]) -> None:
+    tab = "\t"
+    if len(users) == 0:
+        users["THROWAWAY DO NOT USE!!!"] = generate_token()
+    with open(CADDY_SNIPPET, "wb") as f:
+        f.write(b"@noApiKey {\n")
+        for user, key in users.items():
+            f.write(f"{tab}#api key for {user}\n".encode())
+            f.write(f'{tab}not header Authorization "Bearer {key}"\n'.encode())
+        f.write(b"}\n\n")
+        f.write(b"@withApiKey {\n")
+        for user, key in users.items():
+            f.write(f"{tab}#api key for {user}\n".encode())
+            f.write(f'{tab}header Authorization "Bearer {key}"\n'.encode())
+        f.write(b"}\n\n")
+    print(f"Compiled Caddyfile snippet to '{CADDY_SNIPPET}'")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--compile":
+        users = read_users()
+        compile(users)
+        sys.exit(0)
+
+    user = input(
+        "User reference (e.g. email) for new key. Empty for only compiling Caddyfile snippet: "
+    ).strip()
+    users = read_users()
+    if len(user) > 0 and len(user) < 3:
+        sys.exit("User name needs to be >=3 characters")
+    if user in users.keys():
+        sys.exit("User name not unique")
+    token = generate_token()
+    if len(user):
+        users[user] = token
+        dump_users(users)
+    compile(users)

--- a/apikeys/apikeys.py
+++ b/apikeys/apikeys.py
@@ -39,9 +39,9 @@ def read_users() -> Dict[str, str]:
             }
         if "username" in users:
             users.pop("username")
-        if any(len(key) < 32 for key in users.values()):
+        if any(len(key) < 64 for key in users.values()):
             sys.exit(
-                f"Malformed keys: {list(filter(lambda _: len(_) < 32, users.values()))}"
+                f"Malformed keys: {list(filter(lambda _: len(_) < 64, users.values()))}"
             )
         return users
     except FileNotFoundError:

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,0 +1,14 @@
+FROM caddy:2.10.0-builder AS builder
+
+RUN xcaddy build \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2 \
+    --with github.com/mholt/caddy-ratelimit
+
+
+FROM caddy:2.10.0
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+ENTRYPOINT /usr/bin/caddy
+
+CMD ["docker-proxy"]

--- a/docker-compose.rate_limit.yaml
+++ b/docker-compose.rate_limit.yaml
@@ -1,0 +1,111 @@
+### docker compose overrides for rate limiting
+#
+# Usage:
+#   add the override via `-f docker-compose.rate_limit.yaml`, e.g.:
+#   ```
+#   docker compose -f docker-compose.yml -f docker-compose.rate_limit.yaml up -d
+#   ```
+#
+# Note: the custom caddy container needs to be build before use:
+#
+#   ```
+#   docker compose -f docker-compose.yml -f docker-compose.rate_limit.yaml build caddy
+#   ```
+#
+# Management of API keys for premium access via the `apikeys` script in `./apikeys/apikeys.py`.
+# See script header for documentation!
+
+services:
+  compiler:
+    image: ghcr.io/astral-sh/uv:python3.13-alpine
+    volumes:
+      - ./apikeys/apikeys.py:/apikeys.py
+      - ${DATA_DIR:-./data}:/data
+    environment:
+      - KEYS_FILE=/data/keys.csv
+      - CADDY_SNIPPET=/data/apikeys.caddy
+    command: uv run --script /apikeys.py --compile
+  shutter-api:
+    labels:
+      ## Rate limiting:
+      # Make sure to mount compiled 'apikeys' file to this path in caddy container:
+      caddy.import: /etc/caddy/apikeys
+      caddy.handle_errors: 429
+      caddy.handle_errors.respond: "\"Error {err.status_code}. You're rate limited. You can try again in {http.response.header.Retry-After} seconds. See documentation!\""
+
+      # Rate limits unauthorized
+      caddy.rate_limit_0: "@noApiKey"
+      caddy.rate_limit_0.log_key: " "
+
+      caddy.rate_limit_0.zone_0: register_identity__unauthorized
+      caddy.rate_limit_0.zone_0.key: "{remote_host}"
+      caddy.rate_limit_0.zone_0.events: 5
+      caddy.rate_limit_0.zone_0.window: 1d
+      caddy.rate_limit_0.zone_0.match.path: "*/register_identity*"
+      caddy.rate_limit_0.zone_0.match.method: POST
+
+      caddy.rate_limit_0.zone_1: get_data_for_encryption__unauthorized
+      caddy.rate_limit_0.zone_1.key: "{remote_host}"
+      caddy.rate_limit_0.zone_1.events: 10
+      caddy.rate_limit_0.zone_1.window: 1d
+      caddy.rate_limit_0.zone_1.match.path: "*/get_data_for_encryption*"
+      caddy.rate_limit_0.zone_1.match.method: GET
+
+      caddy.rate_limit_0.zone_2: get_decryption_key__unauthorized
+      caddy.rate_limit_0.zone_2.key: "{remote_host}"
+      caddy.rate_limit_0.zone_2.events: 20
+      caddy.rate_limit_0.zone_2.window: 1d
+      caddy.rate_limit_0.zone_2.match.path: "*/get_decryption_key*"
+      caddy.rate_limit_0.zone_2.match.method: GET
+
+      caddy.rate_limit_0.zone_3: decrypt_commitment__unauthorized
+      caddy.rate_limit_0.zone_3.key: "{remote_host}"
+      caddy.rate_limit_0.zone_3.events: 10
+      caddy.rate_limit_0.zone_3.window: 1d
+      caddy.rate_limit_0.zone_3.match.path: "*/decrypt_commitment*"
+      caddy.rate_limit_0.zone_3.match.method: GET
+
+      # Rate limits with api key
+      caddy.rate_limit_1: "@withApiKey"
+      caddy.rate_limit_1.log_key: " "
+
+      caddy.rate_limit_1.zone_0: register_identity__authorized
+      caddy.rate_limit_1.zone_0.key: "{header.Authorization}"
+      caddy.rate_limit_1.zone_0.events: 500
+      caddy.rate_limit_1.zone_0.window: 1d
+      caddy.rate_limit_1.zone_0.match.path: "*/register_identity*"
+      caddy.rate_limit_1.zone_0.match.method: POST
+
+      caddy.rate_limit_1.zone_1: get_data_for_encryption__authorized
+      caddy.rate_limit_1.zone_1.key: "{header.Authorization}"
+      caddy.rate_limit_1.zone_1.events: 1000
+      caddy.rate_limit_1.zone_1.window: 1d
+      caddy.rate_limit_1.zone_1.match.path: "*/get_data_for_encryption*"
+      caddy.rate_limit_1.zone_1.match.method: GET
+
+      caddy.rate_limit_1.zone_2: get_decryption_key__authorized
+      caddy.rate_limit_1.zone_2.key: "{header.Authorization}"
+      caddy.rate_limit_1.zone_2.events: 2000
+      caddy.rate_limit_1.zone_2.window: 1d
+      caddy.rate_limit_1.zone_2.match.path: "*/get_decryption_key*"
+      caddy.rate_limit_1.zone_2.match.method: GET
+
+      caddy.rate_limit_1.zone_3: decrypt_commitment__authorized
+      caddy.rate_limit_1.zone_3.key: "{header.Authorization}"
+      caddy.rate_limit_1.zone_3.events: 1000
+      caddy.rate_limit_1.zone_3.window: 1d
+      caddy.rate_limit_1.zone_3.match.path: "*/decrypt_commitment*"
+      caddy.rate_limit_1.zone_3.match.method: GET
+
+  caddy:
+    build:
+      context: .
+      dockerfile: caddy/Dockerfile
+    image: caddy-docker-proxy-rate-limit
+    volumes:
+      - ${DATA_DIR:-./data}/apikeys.caddy:/etc/caddy/apikeys
+    entrypoint: /usr/bin/caddy
+    command: docker-proxy run
+    depends_on:
+      compiler:
+          condition: service_completed_successfully

--- a/docker-compose.rate_limit.yaml
+++ b/docker-compose.rate_limit.yaml
@@ -31,7 +31,7 @@ services:
       # Make sure to mount compiled 'apikeys' file to this path in caddy container:
       caddy.import: /etc/caddy/apikeys
       caddy.handle_errors: 429
-      caddy.handle_errors.respond: "`{\"error\": \"Request is rate limited. See documentation!\", \"retry_after_seconds\": {http.response.header.Retry-After}, \"status\": {err.status_code}}`"
+      caddy.handle_errors.respond: "`{\"error\": \"Request is rate limited. See documentation! https://github.com/shutter-network/shutter-api?tab=readme-ov-file#rate-limits--authorization\", \"retry_after_seconds\": {http.response.header.Retry-After}, \"status\": {err.status_code}}`"
       caddy.handle_errors.header.Content-type: "application/json"
 
       # Rate limits unauthorized

--- a/docker-compose.rate_limit.yaml
+++ b/docker-compose.rate_limit.yaml
@@ -31,7 +31,8 @@ services:
       # Make sure to mount compiled 'apikeys' file to this path in caddy container:
       caddy.import: /etc/caddy/apikeys
       caddy.handle_errors: 429
-      caddy.handle_errors.respond: "\"Error {err.status_code}. You're rate limited. You can try again in {http.response.header.Retry-After} seconds. See documentation!\""
+      caddy.handle_errors.respond: "`{\"error\": \"Request is rate limited. See documentation!\", \"retry_after_seconds\": {http.response.header.Retry-After}, \"status\": {err.status_code}}`"
+      caddy.handle_errors.header.Content-type: "application/json"
 
       # Rate limits unauthorized
       caddy.rate_limit_0: "@noApiKey"


### PR DESCRIPTION
This adds rate limiting and premium access to shutter API.

It is realized via the caddy plugin github.com/mholt/caddy-ratelimit

It consists of the following elements:

- A docker compose override file `docker-compose.rate_limit.yaml`
- A custom `Dockerfile` for github.com/lucaslorentz/caddy-docker-proxy with `caddy-ratelimit` installed
- A python script for managing API keys `apikeys/apikeys.py`

API keys are stored in the file `${DATA_DIR}/keys.csv` -- make sure to manage that location persistent!

Documentation on usage in headers of `docker-compose.rate_limit.yaml` and `apikeys/apikeys.py`.

Fixes #57
Fixes #59